### PR TITLE
chore(ci): add ci_generate_score.sh to generate audit artifacts

### DIFF
--- a/.github/workflows/ci-audit-generate.yml
+++ b/.github/workflows/ci-audit-generate.yml
@@ -1,0 +1,38 @@
+name: CI Audit Generate
+
+on:
+  workflow_dispatch: {}
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  generate-score:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Enable corepack and setup pnpm
+        run: |
+          corepack enable || true
+          corepack prepare pnpm@8.7.0 --activate || true
+
+      - name: Install dependencies and run audit
+        run: |
+          chmod +x scripts/ci_generate_score.sh
+          ./scripts/ci_generate_score.sh
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: audit-artifacts
+          path: artifacts/


### PR DESCRIPTION
Agrega script que genera artifacts/score.json y pnpm-audit.json para el pipeline de auditoría CI.